### PR TITLE
[#23] Product Service - 상품 재고 변경, FeignClient의 PATCH method 호환 문제

### DIFF
--- a/com.sparta.logistics.product/src/main/java/com/sparta/logistics/product/application/service/ProductService.java
+++ b/com.sparta.logistics.product/src/main/java/com/sparta/logistics/product/application/service/ProductService.java
@@ -60,12 +60,8 @@ public class ProductService {
 
     public Product changeProductQuantity(ProductForUpdateQuantity productForUpdate, Long updatedBy) {
         return handleException(() -> {
-
-            Company company = companyService.validateAndGetSupplierCompany(updatedBy);
-            Product product = productQueryOutputPort.findById(productForUpdate.getId())
+            productQueryOutputPort.findById(productForUpdate.getId())
                 .orElseThrow(() -> new ProductLogicException("유효하지 않은 상품 식별자"));
-            product.validateMatchedCompany(company);
-
             return productOutputPort.changeProductQuantity(productForUpdate, updatedBy);
 
         }, ProductUpdateFailureException::new);

--- a/com.sparta.logistics.product/src/main/java/com/sparta/logistics/product/presentation/rest/controller/ProductCommandController.java
+++ b/com.sparta.logistics.product/src/main/java/com/sparta/logistics/product/presentation/rest/controller/ProductCommandController.java
@@ -68,7 +68,7 @@ public class ProductCommandController {
         return ApiResponse.success(response, HttpStatus.OK);
     }
 
-    @PatchMapping("/{productId}/quantity")
+    @PostMapping("/{productId}/quantity")
     public ResponseEntity<Success<Response>> changeProductQuantity(
         @PathVariable("productId") Long productId,
         @RequestBody ProductQuantityModification.Request request


### PR DESCRIPTION
## 📝 작업 내용

> 상품 재고 로직 변경 및 Http 메소드 변경

상품 재고 변경 시 본인 업체의 상품만 변경 가능한 문제 발생
- 상풍 재고 변경 로직에서는 본인 업체의 상품인지 검증하는 로직을 제거함.

OpenFeign 은 PATCH method를 지원하지 않음.
- 일단 POST로 처리하고 OkHTTP 같은 PATCH method를 지원하는 라이브러리 사용으로 해결 예정

## #️⃣ 연관 이슈
- #23 

resolved: #23
